### PR TITLE
feat: add Tailwind CSS pipeline and styleguide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ temp/
 # IDE directories
 .idea/
 .vscode/
+
+# Generated assets
+static/assets/

--- a/package.json
+++ b/package.json
@@ -3,12 +3,15 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "dev": "eleventy --serve",
-    "build": "eleventy",
+    "dev": "npx tailwindcss -i ./src/assets/css/main.css -o ./static/assets/main.css --watch & eleventy --serve",
+    "build": "npx tailwindcss -i ./src/assets/css/main.css -o ./static/assets/main.css && eleventy",
     "lint": "echo 'lint placeholder'; exit 0",
     "test": "echo 'test placeholder'; exit 0"
   },
   "devDependencies": {
-    "@11ty/eleventy": "^2.0.1"
+    "@11ty/eleventy": "^2.0.1",
+    "tailwindcss": "^3.4.1",
+    "postcss": "^8.4.35",
+    "autoprefixer": "^10.4.16"
   }
 }

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/index.njk
+++ b/src/index.njk
@@ -5,6 +5,7 @@ title: Hello Tenerife
 <html lang="en">
   <head>
     <meta charset="UTF-8">
+    <link rel="stylesheet" href="/assets/main.css">
     <title>{{ title }}</title>
   </head>
   <body>

--- a/src/styleguide/index.njk
+++ b/src/styleguide/index.njk
@@ -1,0 +1,29 @@
+---
+title: Styleguide
+---
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>{{ title }}</title>
+    <link rel="stylesheet" href="/assets/main.css">
+  </head>
+  <body>
+    <h1>Heading 1</h1>
+    <h2>Heading 2</h2>
+    <h3>Heading 3</h3>
+    <h4>Heading 4</h4>
+    <h5>Heading 5</h5>
+    <h6>Heading 6</h6>
+    <p>Paragraph with <a href="#">a link</a>.</p>
+    <ul>
+      <li>Unordered item one</li>
+      <li>Unordered item two</li>
+    </ul>
+    <ol>
+      <li>Ordered item one</li>
+      <li>Ordered item two</li>
+    </ol>
+    <blockquote>Sample blockquote.</blockquote>
+  </body>
+</html>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ["./src/**/*.{html,njk}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- setup Tailwind CSS with PostCSS and autoprefixer
- add base Tailwind stylesheet and link it to pages
- create basic styleguide page with common elements

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tailwindcss)*

------
https://chatgpt.com/codex/tasks/task_e_68a9dc04e330832b947ce6832c6c2a9c