### PR TITLE
feat: add RSS feed for posts

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,9 @@
 export default function(eleventyConfig) {
   eleventyConfig.addPassthroughCopy("static");
+
+  eleventyConfig.addFilter("rssDate", (dateObj) => dateObj.toUTCString());
+  eleventyConfig.addFilter("absoluteUrl", (path, base) => new URL(path, base).toString());
+
   return {
     dir: {
       input: "src",

--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -1,0 +1,5 @@
+{
+  "title": "Hello Tenerife",
+  "description": "A simple site",
+  "url": "https://example.com"
+}

--- a/src/feed.njk
+++ b/src/feed.njk
@@ -1,0 +1,23 @@
+---
+permalink: /feed.xml
+eleventyExcludeFromCollections: true
+---
+{% set posts = collections.posts | reverse %}
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ site.title }}</title>
+    <link>{{ site.url }}</link>
+    <description>{{ site.description }}</description>
+    <atom:link href="{{ site.url }}/feed.xml" rel="self" type="application/rss+xml" />
+    {% for post in posts %}
+    <item>
+      <title>{{ post.data.title }}</title>
+      <link>{{ post.url | absoluteUrl(site.url) }}</link>
+      <guid>{{ post.url | absoluteUrl(site.url) }}</guid>
+      <pubDate>{{ post.date | rssDate }}</pubDate>
+      <description>{{ (post.data.description or post.templateContent | striptags | truncate(160)) | escape }}</description>
+    </item>
+    {% endfor %}
+  </channel>
+</rss>

--- a/src/index.njk
+++ b/src/index.njk
@@ -6,6 +6,7 @@ title: Hello Tenerife
   <head>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="/assets/main.css">
+    <link rel="alternate" type="application/rss+xml" href="/feed.xml">
     <title>{{ title }}</title>
   </head>
   <body>

--- a/src/posts/posts.11tydata.js
+++ b/src/posts/posts.11tydata.js
@@ -1,0 +1,1 @@
+export const tags = ["posts"];

--- a/src/styleguide/index.njk
+++ b/src/styleguide/index.njk
@@ -7,6 +7,7 @@ title: Styleguide
     <meta charset="UTF-8">
     <title>{{ title }}</title>
     <link rel="stylesheet" href="/assets/main.css">
+    <link rel="alternate" type="application/rss+xml" href="/feed.xml">
   </head>
   <body>
     <h1>Heading 1</h1>


### PR DESCRIPTION
## Summary
- generate `feed.xml` from the posts collection
- expose RSS feed link in page heads
- provide site metadata and filters for RSS output

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tailwindcss)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e4cb01bc832b92e7a84fe9953515