### PR TITLE
feat: add Lunr search

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,8 +1,19 @@
 export default function(eleventyConfig) {
   eleventyConfig.addPassthroughCopy("static");
+  eleventyConfig.addPassthroughCopy({ "src/assets/js": "assets" });
 
   eleventyConfig.addFilter("rssDate", (dateObj) => dateObj.toUTCString());
   eleventyConfig.addFilter("absoluteUrl", (path, base) => new URL(path, base).toString());
+
+  eleventyConfig.addFilter("excerpt", (text, words = 200) => {
+    if (!text) return "";
+    const content = text.replace(/<[^>]+>/g, "");
+    return content.trim().split(/\s+/).slice(0, words).join(" ");
+  });
+
+  eleventyConfig.addCollection("search", (collection) =>
+    collection.getAll().filter((item) => item.data.title && !item.data.excludeFromSearch)
+  );
 
   return {
     dir: {

--- a/src/assets/js/search.js
+++ b/src/assets/js/search.js
@@ -1,0 +1,33 @@
+(async function() {
+  const res = await fetch('/search.json');
+  const docs = await res.json();
+  const idx = lunr(function () {
+    this.ref('url');
+    this.field('title');
+    this.field('tags');
+    this.field('excerpt');
+    docs.forEach(doc => this.add(doc));
+  });
+
+  const input = document.getElementById('search-input');
+  const results = document.getElementById('search-results');
+
+  input.addEventListener('input', function() {
+    const query = this.value.trim();
+    results.innerHTML = '';
+    if (!query) return;
+    idx.search(query).forEach(result => {
+      const doc = docs.find(d => d.url === result.ref);
+      if (!doc) return;
+      const li = document.createElement('li');
+      const a = document.createElement('a');
+      a.href = doc.url;
+      a.textContent = doc.title;
+      const p = document.createElement('p');
+      p.textContent = doc.excerpt;
+      li.appendChild(a);
+      li.appendChild(p);
+      results.appendChild(li);
+    });
+  });
+})();

--- a/src/search.json.njk
+++ b/src/search.json.njk
@@ -1,0 +1,14 @@
+---
+permalink: /search.json
+eleventyExcludeFromCollections: true
+---
+[
+{% for page in collections.search %}
+  {
+    "title": {{ page.data.title | dump | safe }},
+    "url": {{ page.url | dump | safe }},
+    "tags": {{ (page.data.tags or []) | dump | safe }},
+    "excerpt": {{ (page.templateContent | striptags | excerpt(200)) | dump | safe }}
+  }{% if not loop.last %},{% endif %}
+{% endfor %}
+]

--- a/src/search.njk
+++ b/src/search.njk
@@ -1,0 +1,21 @@
+---
+title: Search
+excludeFromSearch: true
+---
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="stylesheet" href="/assets/main.css" />
+    <title>{{ title }}</title>
+  </head>
+  <body>
+    <h1>{{ title }}</h1>
+    <form>
+      <input type="search" id="search-input" placeholder="Search..." />
+    </form>
+    <ul id="search-results"></ul>
+    <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="/assets/search.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- generate search index with excerpt filter
- add search page and client-side script using Lunr.js

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tailwindcss)*

------
https://chatgpt.com/codex/tasks/task_e_68a9edfc8ecc832bb5b1ed79a2239868