### PR TITLE
feat: add backlinks collection

### DIFF
--- a/src/_includes/backlinks.njk
+++ b/src/_includes/backlinks.njk
@@ -1,0 +1,12 @@
+{% set key = page.url | urlKey %}
+{% set links = collections.backlinks[key] %}
+{% if links and (links | length) %}
+<section>
+  <h2>Liens connexes</h2>
+  <ul>
+  {% for item in links | slice(0, 5) %}
+    <li><a href="{{ item.url }}">{{ item.data.title }}</a></li>
+  {% endfor %}
+  </ul>
+</section>
+{% endif %}

--- a/src/index.njk
+++ b/src/index.njk
@@ -11,5 +11,6 @@ title: Hello Tenerife
   </head>
   <body>
     <h1>{{ title }}</h1>
+    {% include "backlinks.njk" %}
   </body>
 </html>

--- a/src/search.njk
+++ b/src/search.njk
@@ -17,5 +17,6 @@ excludeFromSearch: true
     <ul id="search-results"></ul>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
     <script src="/assets/search.js"></script>
+    {% include "backlinks.njk" %}
   </body>
 </html>

--- a/src/styleguide/index.njk
+++ b/src/styleguide/index.njk
@@ -26,5 +26,6 @@ title: Styleguide
       <li>Ordered item two</li>
     </ol>
     <blockquote>Sample blockquote.</blockquote>
+    {% include "backlinks.njk" %}
   </body>
 </html>


### PR DESCRIPTION
## Summary
- compute backlinks from glossary auto-links
- display related pages section when backlinks exist

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tailwindcss)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f1a65c10832bbc2de7a7ca994124