### PR TITLE
feat: add contact form page

### DIFF
--- a/src/_data/env.js
+++ b/src/_data/env.js
@@ -1,0 +1,3 @@
+export default {
+  FORMSPREE_ENDPOINT: process.env.FORMSPREE_ENDPOINT || ""
+};

--- a/src/assets/js/contact.js
+++ b/src/assets/js/contact.js
@@ -1,0 +1,28 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('contact-form');
+  const status = document.getElementById('form-status');
+
+  if (!form) return;
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const formData = new FormData(form);
+
+    try {
+      const response = await fetch(form.action, {
+        method: 'POST',
+        body: formData,
+        headers: { Accept: 'application/json' }
+      });
+
+      if (response.ok) {
+        status.textContent = 'Thanks for your message!';
+        form.reset();
+      } else {
+        status.textContent = 'Oops! There was a problem submitting your form.';
+      }
+    } catch {
+      status.textContent = 'Oops! There was a problem submitting your form.';
+    }
+  });
+});

--- a/src/contact.njk
+++ b/src/contact.njk
@@ -1,0 +1,30 @@
+---
+title: Contact
+---
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="stylesheet" href="/assets/main.css" />
+    <title>{{ title }}</title>
+  </head>
+  <body>
+    <h1>{{ title }}</h1>
+    <form id="contact-form" action="{{ env.FORMSPREE_ENDPOINT }}" method="POST">
+      <label for="name">Name</label>
+      <input type="text" id="name" name="name" required />
+
+      <label for="email">Email</label>
+      <input type="email" id="email" name="email" required />
+
+      <label for="message">Message</label>
+      <textarea id="message" name="message" required></textarea>
+
+      <input type="text" name="_honeypot" id="honeypot" aria-hidden="true" tabindex="-1" style="display:none" />
+
+      <button type="submit">Send</button>
+    </form>
+    <p id="form-status"></p>
+    <script src="/assets/contact.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add contact page posting to FORMSPREE_ENDPOINT env
- include honeypot and client-side feedback script

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9f8f48d24832bb0d14ff66b4e0ad4