### PR TITLE
feat(styleguide): document base typography

### DIFF
--- a/src/styleguide/index.njk
+++ b/src/styleguide/index.njk
@@ -10,23 +10,24 @@ comments: true
     <link rel="stylesheet" href="/assets/main.css">
     <link rel="alternate" type="application/rss+xml" href="/feed.xml">
   </head>
-  <body>
-    <h1>Heading 1</h1>
-    <h2>Heading 2</h2>
-    <h3>Heading 3</h3>
-    <h4>Heading 4</h4>
-    <h5>Heading 5</h5>
-    <h6>Heading 6</h6>
-    <p>Paragraph with <a href="#">a link</a>.</p>
-    <ul>
+  <body class="p-4 space-y-4 font-sans text-gray-800">
+    <h1 class="text-4xl font-bold">Heading 1</h1>
+    <h2 class="text-3xl font-bold">Heading 2</h2>
+    <h3 class="text-2xl font-semibold">Heading 3</h3>
+    <h4 class="text-xl font-semibold">Heading 4</h4>
+    <h5 class="text-lg font-semibold">Heading 5</h5>
+    <h6 class="text-base font-semibold">Heading 6</h6>
+    <p class="text-base">Paragraph with <a class="text-blue-600 underline" href="#">a link</a>.</p>
+    <ul class="list-disc pl-6 space-y-1">
       <li>Unordered item one</li>
       <li>Unordered item two</li>
     </ul>
-    <ol>
+    <ol class="list-decimal pl-6 space-y-1">
       <li>Ordered item one</li>
       <li>Ordered item two</li>
     </ol>
-    <blockquote>Sample blockquote.</blockquote>
+    <blockquote class="border-l-4 border-gray-300 pl-4 italic text-gray-700">Sample blockquote.</blockquote>
+    <button class="px-4 py-2 bg-blue-500 text-white rounded">Button</button>
     {% include "backlinks.njk" %}
     {% if comments %}
       {% include "comments.njk" %}


### PR DESCRIPTION
## Summary
- add `/styleguide` page showing headings, lists, blockquote, link, and button using Tailwind utility classes
- apply a basic typographic baseline with spacing and gray text

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa017f6abc832bbd50fbe05d21f3ad