### PR TITLE
feat: add CLI to scaffold pages and posts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "prebuild": "node scripts/generate-demo-images.js",
     "build": "npx tailwindcss -i ./src/assets/css/main.css -o ./static/assets/main.css && eleventy && npx cleancss -o ./dist/assets/main.css ./dist/assets/main.css",
     "lint": "echo 'lint placeholder'; exit 0",
-    "test": "echo 'test placeholder'; exit 0"
+    "test": "echo 'test placeholder'; exit 0",
+    "new:page": "node scripts/new-page.mjs --type=page --title",
+    "new:post": "node scripts/new-page.mjs --type=post --title"
   },
   "dependencies": {
     "@11ty/eleventy-img": "^3.0.0"

--- a/scripts/new-page.mjs
+++ b/scripts/new-page.mjs
@@ -1,0 +1,69 @@
+import fs from 'fs';
+import path from 'path';
+
+// Simple argument parser for --key=value pairs
+const args = Object.fromEntries(
+  process.argv.slice(2).map(arg => {
+    const [key, ...rest] = arg.replace(/^--/, '').split('=');
+    return [key, rest.length ? rest.join('=') : ''];
+  })
+);
+
+const type = args.type || 'page';
+const title = args.title || process.env.npm_config_title;
+const providedSlug = args.slug || process.env.npm_config_slug;
+
+if (!title) {
+  console.error('Missing required --title argument');
+  process.exit(1);
+}
+
+// Slugify function: lower-case, remove accents, non-alphanumeric to hyphen
+const slugify = str =>
+  str
+    .normalize('NFD')
+    .replace(/[^\w\s-]/g, '')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)+/g, '');
+
+const slug = providedSlug ? slugify(providedSlug) : slugify(title);
+
+const now = new Date();
+let destDir;
+let filename;
+
+if (type === 'post') {
+  const datePrefix = now.toISOString().slice(0, 10);
+  destDir = path.join('src', 'content', 'posts');
+  filename = `${datePrefix}-${slug}.md`;
+} else {
+  destDir = path.join('src', 'content', 'pages');
+  filename = `${slug}.md`;
+}
+
+// Ensure destination directory exists
+fs.mkdirSync(destDir, { recursive: true });
+
+const filePath = path.join(destDir, filename);
+
+const frontMatterLines = [
+  '---',
+  `title: "${title}"`,
+  'description: ""',
+];
+
+if (type === 'post') {
+  frontMatterLines.push(`date: "${now.toISOString()}"`);
+}
+
+frontMatterLines.push(`layout: "layouts/${type}.njk"`);
+frontMatterLines.push('tags: []');
+frontMatterLines.push('---', '', `# ${title}`, '', 'Contenu à écrire…', '');
+
+fs.writeFileSync(filePath, frontMatterLines.join('\n'));
+
+console.log(`Created ${filePath}`);
+


### PR DESCRIPTION
## Summary
- add `scripts/new-page.mjs` to scaffold markdown pages and posts with front matter
- expose `new:page` and `new:post` npm scripts for easy invocation

## Testing
- `npm run new:page --title="À propos"`
- `npm run new:post --title="Hello RSS"`
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Cannot find package '@11ty/eleventy-img')*

------
https://chatgpt.com/codex/tasks/task_e_68aa0c93b1f8832b8112c989e85b6a4a