### PR TITLE
feat: add 404 and 500 error pages

### DIFF
--- a/src/404.njk
+++ b/src/404.njk
@@ -1,0 +1,17 @@
+---
+layout: base.njk
+title: Page non trouvée
+permalink: /404.html
+noindex: true
+---
+<h1>Page non trouvée</h1>
+<p>La page que vous cherchez n'existe pas ou a été déplacée.</p>
+<p><a href="/">Retour à l'accueil</a></p>
+{% set searchPage = collections.all | selectattr("url","equalto","/search/") | first %}
+{% if searchPage %}
+<form action="/search/" method="get">
+  <label for="search">Recherche</label>
+  <input type="search" id="search" name="q" />
+  <button type="submit">Rechercher</button>
+</form>
+{% endif %}

--- a/src/500.njk
+++ b/src/500.njk
@@ -1,0 +1,9 @@
+---
+layout: base.njk
+title: Erreur serveur
+permalink: /500.html
+noindex: true
+---
+<h1>Erreur serveur</h1>
+<p>Une erreur est survenue. Veuillez réessayer plus tard.</p>
+<p><a href="/">Retour à l'accueil</a></p>

--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <link rel="stylesheet" href="/assets/main.css">
     <title>{{ title }}</title>
+    {% if noindex %}
+    <meta name="robots" content="noindex" />
+    {% endif %}
   </head>
   <body class="bg-white text-slate-800">
     <a class="skip-link sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:p-2 focus:bg-white" href="#main">Aller au contenu</a>


### PR DESCRIPTION
## Summary
- add dedicated 404 and 500 Nunjucks templates with home links and search
- support noindex meta tag in base layout for error pages

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Cannot find package '@11ty/eleventy-img')*

------
https://chatgpt.com/codex/tasks/task_e_68aa2cfb0b08832b88e3b067b768b305