### PR TITLE
feat: add locale routing with browser detection

### DIFF
--- a/.eleventy.cjs
+++ b/.eleventy.cjs
@@ -40,6 +40,19 @@ module.exports = function(eleventyConfig) {
       const segments = (data.page?.filePathStem || "").split("/");
       const lang = segments[1];
       return locales.includes(lang) ? lang : site.defaultLocale;
+    },
+    baseUrl: (data) => {
+      const segments = (data.page?.filePathStem || "").split("/").slice(2);
+      const slug = segments.join("/");
+      return slug === "index" ? "/" : `/${slug}/`;
+    },
+    permalink: (data) => {
+      if (data.permalink) return data.permalink;
+      const segments = (data.page?.filePathStem || "").split("/");
+      const locale = segments[1];
+      const slug = segments.slice(2).join("/");
+      const path = slug === "index" ? "/" : `/${slug}/`;
+      return i18nPath(path, locale, site.defaultLocale);
     }
   });
 

--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -1,18 +1,37 @@
 <!DOCTYPE html>
-<html lang="{{ page.lang }}">
+<html lang="{{ page.lang }}" class="no-js">
   <head>
     <meta charset="UTF-8">
+    <script>document.documentElement.classList.remove('no-js');</script>
+    <script src="/assets/i18n-detect.js"></script>
     <link rel="stylesheet" href="/assets/main.css">
     <title>{{ title }}</title>
     {% if noindex %}
     <meta name="robots" content="noindex" />
     {% endif %}
+    {% set baseUrl = page.url %}
+    {% if page.lang != site.defaultLocale %}
+      {% set baseUrl = baseUrl | replace('/' + page.lang + '/', '/') %}
+    {% endif %}
+    {% for loc in site.locales %}
+      <link rel="alternate" hreflang="{{ loc }}" href="{{ baseUrl | i18nPath(loc) }}">
+    {% endfor %}
   </head>
   <body class="bg-white text-slate-800">
     <a class="skip-link sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:p-2 focus:bg-white" href="#main">Aller au contenu</a>
     <nav aria-label="Main navigation">
       <a href="{{ '/' | i18nPath(page.lang) }}">{{ 'home' | t(page.lang) }}</a>
       <a href="{{ '/contact/' | i18nPath(page.lang) }}">{{ 'contact' | t(page.lang) }}</a>
+    </nav>
+    <nav aria-label="Language selector">
+      {% for loc in site.locales %}
+        {% if loc == page.lang %}
+          <span aria-current="page">{{ loc | upper }}</span>
+        {% else %}
+          <a href="{{ baseUrl | i18nPath(loc) }}">{{ loc | upper }}</a>
+        {% endif %}
+        {% if not loop.last %} {% endif %}
+      {% endfor %}
     </nav>
     <main id="main">
       {% block content %}{% endblock %}

--- a/src/assets/js/i18n-detect.js
+++ b/src/assets/js/i18n-detect.js
@@ -1,0 +1,21 @@
+(function(){
+  var supported = ['en','fr','es'];
+  var path = location.pathname;
+  if (/^\/(fr|es)(\/|$)/.test(path)) return;
+  var isBot = /bot|crawl|spider/i.test(navigator.userAgent);
+  if (isBot) return;
+  var key = 'i18n.locale';
+  try {
+    var stored = localStorage.getItem(key);
+    if (stored && supported.includes(stored) && stored !== 'en') {
+      location.replace('/' + stored + path);
+      return;
+    }
+  } catch (e) {}
+  var lang = (navigator.languages && navigator.languages[0] || navigator.language || 'en').slice(0,2).toLowerCase();
+  if (!supported.includes(lang)) lang = 'en';
+  try { localStorage.setItem(key, lang); } catch (e) {}
+  if (lang !== 'en') {
+    location.replace('/' + lang + path);
+  }
+})();


### PR DESCRIPTION
## Summary
- compute locale-aware base URLs and permalinks
- add early browser language detection script
- expose alternate language links and selector

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cleancss)*

------
https://chatgpt.com/codex/tasks/task_e_68ab757ac704832ba17d1e897168bea3