### PR TITLE
feat: improve base layout accessibility and responsive images

### DIFF
--- a/.eleventy.cjs
+++ b/.eleventy.cjs
@@ -2,10 +2,10 @@ const fs = require("fs");
 const path = require("path");
 const yaml = require("js-yaml");
 const posthtml = require("posthtml");
-const Image = require("@11ty/eleventy-img");
 const { minify } = require("html-minifier-terser");
 const site = require("./_data/site.json");
 const { i18nPath, t } = require("./src/filters/i18n.js");
+const imageShortcode = require("./src/shortcodes/image.js");
 
 const glossaryPath = path.join("_data", "glossary.yml");
 let glossary = {};
@@ -49,25 +49,7 @@ module.exports = function(eleventyConfig) {
     );
   });
 
-  eleventyConfig.addNunjucksAsyncShortcode("image", async (src, alt, sizes) => {
-    const fullSrc = path.join("src", src);
-    const metadata = await Image(fullSrc, {
-      widths: [480, 768, 1024, 1600],
-      formats: ["webp", "jpeg"],
-      outputDir: "./dist/assets/img/",
-      urlPath: "/assets/img/",
-      cacheOptions: {
-        directory: ".cache/img"
-      }
-    });
-    const imageAttributes = {
-      alt,
-      sizes,
-      loading: "lazy",
-      decoding: "async"
-    };
-    return Image.generateHTML(metadata, imageAttributes);
-  });
+    eleventyConfig.addNunjucksAsyncShortcode("image", imageShortcode);
 
   eleventyConfig.addFilter("rssDate", (dateObj) => dateObj.toUTCString());
   eleventyConfig.addFilter("absoluteUrl", (path, base) => new URL(path, base).toString());

--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
-<html lang="{{ page.lang }}">
+<html lang="{{ lang }}">
   <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="{{ description or site.description }}">
     <link rel="stylesheet" href="/assets/main.css">
     <title>{{ title }}</title>
     {% if noindex %}
@@ -9,12 +11,14 @@
     {% endif %}
   </head>
   <body class="bg-white text-slate-800">
-    <a class="skip-link sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:p-2 focus:bg-white" href="#main">Aller au contenu</a>
-    <nav aria-label="Main navigation">
-      <a href="{{ '/' | i18nPath(page.lang) }}">{{ 'home' | t(page.lang) }}</a>
-      <a href="{{ '/contact/' | i18nPath(page.lang) }}">{{ 'contact' | t(page.lang) }}</a>
+    <a href="#main" class="skip-link">Skip to content</a>
+    {% set homeUrl = '/' | i18nPath(lang) %}
+    {% set contactUrl = '/contact/' | i18nPath(lang) %}
+    <nav aria-label="Navigation principale" class="container">
+      <a href="{{ homeUrl }}"{% if page.url == homeUrl %} aria-current="page"{% endif %}>{{ 'home' | t(lang) }}</a>
+      <a href="{{ contactUrl }}"{% if page.url == contactUrl %} aria-current="page"{% endif %}>{{ 'contact' | t(lang) }}</a>
     </nav>
-    <main id="main">
+    <main id="main" class="container">
       {% block content %}{% endblock %}
     </main>
   </body>

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -7,4 +7,25 @@
   button:focus-visible {
     @apply outline-none ring-2 ring-offset-2 ring-blue-600;
   }
+
+  .skip-link {
+    @apply sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:p-4 focus:bg-white;
+  }
+
+  .container {
+    @apply max-w-3xl mx-auto p-4;
+  }
+
+  main p {
+    @apply mb-4;
+  }
+
+  main h1,
+  main h2,
+  main h3,
+  main h4,
+  main h5,
+  main h6 {
+    @apply mt-8 mb-4;
+  }
 }

--- a/src/shortcodes/image.js
+++ b/src/shortcodes/image.js
@@ -1,0 +1,27 @@
+const path = require("path");
+const Image = require("@11ty/eleventy-img");
+
+module.exports = async function imageShortcode(src, alt, sizes = "(max-width: 1600px) 100vw, 1600px") {
+  const fullSrc = path.join("src", src);
+  const metadata = await Image(fullSrc, {
+    widths: [480, 768, 1024, 1600],
+    formats: ["webp", "jpeg"],
+    outputDir: "./dist/assets/img/",
+    urlPath: "/assets/img/",
+    cacheOptions: {
+      directory: ".cache/img"
+    }
+  });
+
+  const imageAttributes = {
+    alt,
+    sizes,
+    loading: "lazy",
+    decoding: "async"
+  };
+
+  return Image.generateHTML(metadata, imageAttributes, {
+    whitespaceMode: "inline"
+  });
+};
+


### PR DESCRIPTION
## Summary
- ensure HTML lang, viewport and description meta tags
- add skip link, navigation a11y, and container typography
- implement responsive image shortcode with WebP and JPEG support

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab75a4f4e8832ba97eb2251a3323ba