### PR TITLE
feat: add accessible language switcher

### DIFF
--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -21,18 +21,10 @@
       <a href="{{ '/' | i18nPath(page.lang) }}">{{ 'home' | t(page.lang) }}</a>
       <a href="{{ '/contact/' | i18nPath(page.lang) }}">{{ 'contact' | t(page.lang) }}</a>
     </nav>
-    <nav aria-label="Language selector">
-      {% for loc in site.locales %}
-        {% if loc == page.lang %}
-          <span aria-current="page">{{ loc | upper }}</span>
-        {% else %}
-          <a href="{{ baseUrl | i18nPath(loc) }}">{{ loc | upper }}</a>
-        {% endif %}
-        {% if not loop.last %} {% endif %}
-      {% endfor %}
-    </nav>
+    {% include "layouts/partials/lang-switcher.njk" %}
     <main id="main">
       {% block content %}{% endblock %}
     </main>
+    <script src="/assets/i18n-switch.js"></script>
   </body>
 </html>

--- a/src/_includes/layouts/partials/lang-switcher.njk
+++ b/src/_includes/layouts/partials/lang-switcher.njk
@@ -1,0 +1,10 @@
+<nav aria-label="Sélecteur de langue" data-lang-switch>
+  {% for loc in site.locales %}
+    {% if loc == page.lang %}
+      <span aria-current="true">{{ loc | upper }}</span>
+    {% else %}
+      <a href="{{ baseUrl | i18nPath(loc) }}" data-locale="{{ loc }}">{{ loc | upper }}</a>
+    {% endif %}
+    {% if not loop.last %} | {% endif %}
+  {% endfor %}
+</nav>

--- a/src/assets/js/i18n-switch.js
+++ b/src/assets/js/i18n-switch.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const switcher = document.querySelector('[data-lang-switch]');
+  if (!switcher) return;
+  switcher.addEventListener('click', (e) => {
+    const link = e.target.closest('a[data-locale]');
+    if (!link) return;
+    try {
+      localStorage.setItem('i18n.locale', link.dataset.locale);
+    } catch {}
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable lang-switcher partial with aria support
- persist language preference via i18n-switch.js utility
- wire switcher into base layout

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac0638e87c832b9bf895a8e9d7b64b