### PR TITLE
feat(theme): introduce minimal modern theme with dark mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,7 +107,8 @@ temp/
 .vscode/
 
 # Generated assets
-static/assets/
+static/assets/*
+!static/assets/theme.css
 
 # Demo images generated at build time
 src/assets/img/*

--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -9,6 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script>document.documentElement.classList.remove('no-js');</script>
     <script src="/assets/i18n-detect.js"></script>
+    <link rel="stylesheet" href="/assets/theme.css">
     <link rel="stylesheet" href="/assets/main.css">
     <title>{{ title }}</title>
     <meta name="description" content="{{ description or site.description }}">
@@ -17,16 +18,14 @@
     {% endif %}
     {% include "layouts/partials/head-seo.njk" %}
   </head>
-  <body class="bg-white text-slate-800">
+  <body>
     <a class="skip-link" href="#main">Skip to content</a>
-    <nav class="container" aria-label="Navigation principale">
-      <a href="{{ '/' | i18nPath(lang) }}"{% if page.url == ('/' | i18nPath(lang)) %} aria-current="page"{% endif %}>{{ 'home' | t(lang) }}</a>
-      <a href="{{ '/contact/' | i18nPath(lang) }}"{% if page.url == ('/contact/' | i18nPath(lang)) %} aria-current="page"{% endif %}>{{ 'contact' | t(lang) }}</a>
-    </nav>
+    {% include "layouts/partials/header.njk" %}
     {% include "layouts/partials/lang-switcher.njk" %}
-    <main id="main" class="container">
+    <main id="main" class="container prose stack">
       {% block content %}{% endblock %}
     </main>
+    {% include "layouts/partials/footer.njk" %}
     <script src="/assets/i18n-switch.js"></script>
   </body>
 </html>

--- a/src/_includes/layouts/partials/footer.njk
+++ b/src/_includes/layouts/partials/footer.njk
@@ -1,0 +1,8 @@
+<footer class="site-footer">
+  <div class="container">
+    <nav aria-label="Footer">
+      <a href="{{ '/legal/' | i18nPath(lang) }}">{{ 'legal' | t(lang) }}</a>
+      <a href="{{ '/contact/' | i18nPath(lang) }}">{{ 'contact' | t(lang) }}</a>
+    </nav>
+  </div>
+</footer>

--- a/src/_includes/layouts/partials/header.njk
+++ b/src/_includes/layouts/partials/header.njk
@@ -1,0 +1,6 @@
+<header class="site-header">
+  <nav class="container" aria-label="Navigation principale">
+    <a href="{{ '/' | i18nPath(lang) }}"{% if page.url == ('/' | i18nPath(lang)) %} aria-current="page"{% endif %}>{{ 'home' | t(lang) }}</a>
+    <a href="{{ '/contact/' | i18nPath(lang) }}"{% if page.url == ('/contact/' | i18nPath(lang)) %} aria-current="page"{% endif %}>{{ 'contact' | t(lang) }}</a>
+  </nav>
+</header>

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1,25 +1,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@layer base {
-  a:focus-visible,
-  button:focus-visible {
-    @apply outline-none ring-2 ring-offset-2 ring-blue-600;
-  }
-
-  .skip-link {
-    @apply sr-only;
-  }
-  .skip-link:focus {
-    @apply not-sr-only absolute top-0 left-0 p-2 bg-white text-blue-600;
-  }
-
-  .container {
-    @apply max-w-3xl mx-auto px-4;
-  }
-
-  main > * + * {
-    @apply mt-4;
-  }
-}

--- a/static/assets/theme.css
+++ b/static/assets/theme.css
@@ -1,0 +1,160 @@
+:root {
+  --bg: #ffffff;
+  --fg: #111111;
+  --muted: #666666;
+  --accent: #0066ee;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #111111;
+    --fg: #f5f5f5;
+    --muted: #999999;
+    --accent: #4da3ff;
+  }
+}
+
+html {
+  background: var(--bg);
+  color: var(--fg);
+  font-family: system-ui, sans-serif;
+  line-height: 1.5;
+}
+
+a {
+  color: var(--accent);
+}
+
+a:hover,
+a:focus-visible {
+  text-decoration: underline;
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.container {
+  max-width: 72ch;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.prose > * + * {
+  margin-top: 1em;
+}
+
+.prose h1,
+.prose h2,
+.prose h3,
+.prose h4,
+.prose h5,
+.prose h6 {
+  line-height: 1.25;
+  margin-top: 2em;
+}
+
+.prose ul,
+.prose ol {
+  padding-left: 1.5em;
+}
+
+.prose blockquote {
+  padding-left: 1em;
+  border-left: 4px solid var(--muted);
+  color: var(--muted);
+  font-style: italic;
+}
+
+.prose code {
+  font-family: ui-monospace, monospace;
+  background: var(--muted);
+  color: var(--bg);
+  padding: 0.2em 0.4em;
+  border-radius: 4px;
+}
+
+.visually-hidden,
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.stack > * + * {
+  margin-top: var(--stack-space, 1rem);
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  background: var(--bg);
+  border-bottom: 1px solid var(--muted);
+}
+
+.site-header nav {
+  display: flex;
+  gap: 1rem;
+  padding: 0.5rem 0;
+}
+
+.site-footer {
+  margin-top: 2rem;
+  padding: 2rem 0;
+  border-top: 1px solid var(--muted);
+  font-size: 0.875rem;
+  color: var(--muted);
+}
+
+.skip-link {
+  left: -9999px;
+  position: absolute;
+}
+
+.skip-link:focus {
+  left: 0;
+  padding: 0.5rem;
+  background: var(--bg);
+  color: var(--accent);
+}
+
+button,
+input[type="submit"] {
+  cursor: pointer;
+  background: var(--accent);
+  color: var(--bg);
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 0.25rem;
+}
+
+button:hover,
+button:focus-visible,
+input[type="submit"]:hover,
+input[type="submit"]:focus-visible {
+  background: var(--fg);
+  color: var(--bg);
+}
+
+input,
+textarea,
+select {
+  font: inherit;
+  color: inherit;
+  background: var(--bg);
+  border: 1px solid var(--muted);
+  padding: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add theme.css with CSS variables, dark mode, typographic utilities and form styles
- add sticky header and simple footer partials
- streamline main.css and wire theme into base layout

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac0988146c832b9dbc4337de02ecce