### PR TITLE
fix: drop missing main.css and load theme stylesheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Marko CMS
 
-Marko CMS is a reusable static-site template that combines Markdown content, Eleventy layouts and Tailwind CSS. It is designed to be deployed on Cloudflare Pages and supports Formspree for forms and Staticman for comments.
+Marko CMS is a reusable static-site template that combines Markdown content and Eleventy layouts. A lightweight theme is provided via `static/assets/theme.css` with optional Tailwind CSS utilities. It is designed to be deployed on Cloudflare Pages and supports Formspree for forms and Staticman for comments.
 
 ## Installation
 

--- a/content/en/search.njk
+++ b/content/en/search.njk
@@ -6,10 +6,10 @@ excludeFromSearch: true
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="/assets/main.css" />
+    <link rel="stylesheet" href="/assets/theme.css" />
     <title>{{ title }}</title>
   </head>
-  <body>
+  <body class="container prose">
     <h1>{{ title }}</h1>
     <form>
       <input type="search" id="search-input" placeholder="Search..." />

--- a/content/en/styleguide/index.njk
+++ b/content/en/styleguide/index.njk
@@ -7,27 +7,27 @@ comments: true
   <head>
     <meta charset="UTF-8">
     <title>{{ title }}</title>
-    <link rel="stylesheet" href="/assets/main.css">
+    <link rel="stylesheet" href="/assets/theme.css">
     <link rel="alternate" type="application/rss+xml" href="/feed.xml">
   </head>
-  <body class="p-4 space-y-4 font-sans text-gray-800">
-    <h1 class="text-4xl font-bold">Heading 1</h1>
-    <h2 class="text-3xl font-bold">Heading 2</h2>
-    <h3 class="text-2xl font-semibold">Heading 3</h3>
-    <h4 class="text-xl font-semibold">Heading 4</h4>
-    <h5 class="text-lg font-semibold">Heading 5</h5>
-    <h6 class="text-base font-semibold">Heading 6</h6>
-    <p class="text-base">Paragraph with <a class="text-blue-600 underline" href="#">a link</a>.</p>
-    <ul class="list-disc pl-6 space-y-1">
+  <body class="container prose">
+    <h1>Heading 1</h1>
+    <h2>Heading 2</h2>
+    <h3>Heading 3</h3>
+    <h4>Heading 4</h4>
+    <h5>Heading 5</h5>
+    <h6>Heading 6</h6>
+    <p>Paragraph with <a href="#">a link</a>.</p>
+    <ul>
       <li>Unordered item one</li>
       <li>Unordered item two</li>
     </ul>
-    <ol class="list-decimal pl-6 space-y-1">
+    <ol>
       <li>Ordered item one</li>
       <li>Ordered item two</li>
     </ol>
-    <blockquote class="border-l-4 border-gray-300 pl-4 italic text-gray-700">Sample blockquote.</blockquote>
-    <button class="px-4 py-2 bg-blue-500 text-white rounded">Button</button>
+    <blockquote>Sample blockquote.</blockquote>
+    <button>Button</button>
     {% include "backlinks.njk" %}
     {% if comments %}
       {% include "comments.njk" %}

--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -10,7 +10,6 @@
     <script>document.documentElement.classList.remove('no-js');</script>
     <script src="/assets/i18n-detect.js"></script>
     <link rel="stylesheet" href="/assets/theme.css">
-    <link rel="stylesheet" href="/assets/main.css">
     <title>{{ title }}</title>
     <meta name="description" content="{{ description or site.description }}">
     {% if noindex %}


### PR DESCRIPTION
## Summary
- remove broken main.css reference and rely on theme.css
- apply theme.css to standalone pages and document theme usage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac13b3e1e4832b9ed11aea711bad2e