### PR TITLE
fix: inline css minification

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "npx tailwindcss -i ./src/assets/css/main.css -o ./static/assets/main.css --watch & eleventy --serve --config=.eleventy.cjs",
     "prebuild": "node scripts/generate-demo-images.js",
-    "build": "npx tailwindcss -i ./src/assets/css/main.css -o ./static/assets/main.css && eleventy --config=.eleventy.cjs && node src/generators/sitemap.cjs && node src/generators/rss.cjs && npx cleancss -o ./dist/assets/main.css ./dist/assets/main.css",
+    "build": "npx tailwindcss -i ./src/assets/css/main.css -o ./static/assets/main.css && eleventy --config=.eleventy.cjs && node src/generators/sitemap.cjs && node src/generators/rss.cjs && node scripts/minify-css.mjs",
     "lint": "echo 'lint placeholder'; exit 0",
     "test": "echo 'test placeholder'; exit 0",
     "new:page": "node scripts/new-page.mjs",

--- a/scripts/minify-css.mjs
+++ b/scripts/minify-css.mjs
@@ -1,0 +1,17 @@
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import CleanCSS from 'clean-css';
+
+const inputPath = './dist/static/assets/main.css';
+const outputPath = './dist/assets/main.css';
+
+const source = await readFile(inputPath, 'utf8');
+const result = new CleanCSS().minify(source);
+
+if (result.errors.length) {
+  console.error(result.errors.join('\n'));
+  process.exit(1);
+}
+
+await mkdir(dirname(outputPath), { recursive: true });
+await writeFile(outputPath, result.styles);


### PR DESCRIPTION
## Summary
- use local clean-css library to minify generated stylesheet
- avoid npx lookup for non-existent cleancss package

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac2064fb08832b81aaf3562efb78a9